### PR TITLE
updated for carma-base-3.7.1 and autoware.ai-3.8.2 releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     # Pull docker image from docker hub
     # XTERM used for better catkin_make output
     docker:
-      - image: usdotfhwastol/autoware.ai:3.6.0
+      - image: usdotfhwastol/autoware.ai:3.8.2
         user: carma
         environment:
           TERM: xterm # use xterm to get full display output from build

--- a/docker/checkout.sh
+++ b/docker/checkout.sh
@@ -17,7 +17,7 @@
 # CARMA packages checkout script
 # Optional argument to set the root checkout directory with no ending '/' default is '~'
 
-set -ex
+set -exo pipefail
 
 dir=~
 while [[ $# -gt 0 ]]; do

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -39,6 +39,6 @@
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
 - [ ] I have read the **CONTRIBUTING** document.
-[CARMA Contributing Guide](Contributing.md) 
+[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
CI updates to allow circle to read errors from our CI scripts, and fixed link to Contributing.md in PULL_REQUEST_TEMPLATE.md
<!--- Describe your changes in detail -->

## Related Issue
[#369](https://github.com/usdot-fhwa-stol/carma-platform/issues/369)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
CircleCI is has been running successfully in spite of test failures. This was due to errors in our code coverage scripts not being passed to the CircleCI shell. This issue has been addressed by carma-base-3.7.1 release, which this PR is designed to incorporate into this repo.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested by breaking the test suite and confirming that Circle fails as expected.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.