### PR TITLE
Adjust pre_build hook for release builds

### DIFF
--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -6,7 +6,8 @@ if [[ "$SOURCE_BRANCH" = "develop" ]]; then
         Dockerfile
 elif [[ "$SOURCE_BRANCH" =~ ^release/.*$ ]]; then
     # swap checkout branch in checkout.bash to release branch
-    sed -i "s|usdotfhwastoldev/|usdotfhwastolcandidate/|g; s|usdotfhwastol/|usdotfhwastolcandidate/|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:candidate|g; s|:CARMA[a-zA-Z]*_[0-9]*\.[0-9]*\.[0-9]*|:candidate|g; s|:carma-[a-zA-Z]*-[0-9]*\.[0-9]*\.[0-9]*|:candidate|g" \
+    RELEASE_NAME=$(echo $SOURCE_BRANCH | cut -d "/" -f 2)
+    sed -i "s|usdotfhwastol/|usdotfhwastolcandidate/|g; s|usdotfhwastoldev/|usdotfhwastolcandidate/|g; s|:[0-9]*\.[0-9]*\.[0-9]*|:$RELEASE_NAME|g; s|:CARMA[a-zA-Z]*_[0-9]*\.[0-9]*\.[0-9]*|:$RELEASE_NAME|g; s|:carma-[a-zA-Z]*-[0-9]*\.[0-9]*\.[0-9]*|:$RELEASE_NAME|g; s|:develop|:$RELEASE_NAME|g" \
         Dockerfile
     sed -i "s|--branch .*|--branch $SOURCE_BRANCH|g" \
         docker/checkout.bash


### PR DESCRIPTION
Fix pre_build hook to convert `develop` into release named docker images.