### PR TITLE
Update ROS Noetic branch to C++14

### DIFF
--- a/velodyne_lidar_driver_wrapper/CMakeLists.txt
+++ b/velodyne_lidar_driver_wrapper/CMakeLists.txt
@@ -16,8 +16,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(velodyne_lidar_driver_wrapper)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++11)
+## Compile as C++14, supported in ROS Noetic and newer
+add_compile_options(-std=c++14)
 set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 


### PR DESCRIPTION
# PR Details
## Description

Update the CMakeLists.txt files to specify c++14 instead of c++11. Also, must use at least cmake 3.1 to use CMAKE_CXX_STANDARD.

## Motivation and Context

Using C++ 14 to compile the CARMA source code on Ubuntu 20.04.

## How Has This Been Tested?

Full build and checking the output logs for C++ 14 usage.

## Checklist:
- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
