### PR TITLE
Fix dockerhub builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - id: docker-org-and-tag
         uses: usdot-fhwa-stol/actions/docker-org-and-tag@main
-        with:
-          docker_tag_suffix: humble
   build:
     needs: determine_docker_org_and_tag
     defaults:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,5 +6,3 @@ on:
 jobs:
   docker:
     uses: usdot-fhwa-stol/actions/.github/workflows/docker.yml@main
-    with:
-      tag_name_suffix: humble

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -12,9 +12,6 @@ on:
 jobs:
   dockerhub:
     uses: usdot-fhwa-stol/actions/.github/workflows/dockerhub.yml@main
-    with:
-      tag_name_suffix: humble
-      remove_suffix: true
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 ARG DOCKER_ORG="usdotfhwastoldev"
-ARG DOCKER_TAG="develop-humble"
+ARG DOCKER_TAG="develop"
 FROM ${DOCKER_ORG}/autoware.ai:${DOCKER_TAG} as base_image
 FROM base_image as setup
 ARG GIT_BRANCH="develop"


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Two issues with current automatic build.
1. carma-velodyne-driver doesn't depend on autoware.aI:develop-humble because there is only autoware.ai:develop
2. it also shouldn't have extra arguments in dockerhub about suffix because base and result images both only have humble and shouldn't need a distinction. In other words, backporting this PR into develop: https://github.com/usdot-fhwa-stol/carma-velodyne-lidar-driver/pull/124

<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
NA
<!-- e.g. CAR-123 -->

## Motivation and Context
ROS2 Humble Regression Testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Docker build
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
